### PR TITLE
Monster Chase #36 - Entities event/action double dispatch

### DIFF
--- a/src/behaviors.cpp
+++ b/src/behaviors.cpp
@@ -230,21 +230,13 @@ BehaviorStatus EntitiesCollisionChecker::exec()
                           _entity_size, _entity_size);
     QPointF new_pos = QPointF(_model->pos_x, _model->pos_y);
 
-    QRectF i = collisionBox.intersected(pbox);
-    if (not i.isEmpty()){
-        GameWorld::instance().getPlayer()->collisionWithMonster();
-        status = success;
-        new_pos = collisionPointFinder::find_substep3(
-                    collisionBox,
-                    pbox,
-                    QPointF(speed_x(_model),speed_y(_model)),
-                    5);
-        collisionBox.moveCenter(new_pos);
-    }
-
+    Monster::Monster* this_monster = nullptr;
     std::vector<Monster::Monster*> monsters = GameWorld::instance().getMonsters();
     for (auto m: monsters){
-        if (m->id() == _model->id) continue;
+        if (m->id() == _model->id){
+        	this_monster = m;
+        	continue;
+        }
         QRectF i = collisionBox.intersected(m->collisionBox());
         if (not i.isEmpty()){
             status = success;
@@ -254,6 +246,18 @@ BehaviorStatus EntitiesCollisionChecker::exec()
                         QPointF(speed_x(_model),speed_y(_model)),
                         5);
         }
+    }
+
+    QRectF i = collisionBox.intersected(pbox);
+    if (not i.isEmpty()){
+        GameWorld::instance().getPlayer()->collisionWithMonster(this_monster);
+        status = success;
+        new_pos = collisionPointFinder::find_substep3(
+                    collisionBox,
+                    pbox,
+                    QPointF(speed_x(_model),speed_y(_model)),
+                    5);
+        collisionBox.moveCenter(new_pos);
     }
 
     _model->pos_x = new_pos.x();

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -127,4 +127,27 @@ namespace Monster{
         delete monster_view;
     }
 
+    int Monster::hit_suffered()
+    {
+    	int score_points = model.score_point;
+    	model.health -= model.damage_suffered_per_hit;
+    	if (model.health <= 0)
+    	{
+    		model.health = 0;
+    		score_points = model.death_score_bonus;
+    		//model.state = MonsterStates::dead; //missing dead state
+    		//by now let it become a ghost :-)
+    		model.death_score_bonus = 0;
+    		model.damage_inflicted_per_hit = 0;
+    		qDebug("monster %d is dead", model.id);
+    	}
+    	qDebug("monster healt is now %d", model.health);
+    	return score_points;
+    }
+
+	int Monster::hit_inflicted()
+	{
+		return model.damage_inflicted_per_hit;
+	}
+
 } //namescpace Monster

--- a/src/monster.h
+++ b/src/monster.h
@@ -76,6 +76,12 @@ class MonsterSm;
         double target_y;
         double target_direction;
         int curent_speed;
+
+        int health;
+        int score_point;
+        int death_score_bonus;
+        int damage_inflicted_per_hit;
+        int damage_suffered_per_hit;
     } ;
 
     class Monster;
@@ -98,6 +104,8 @@ class MonsterSm;
 
         void update();
         int id();
+        int hit_suffered(); //return score points
+        int hit_inflicted(); //return score points
 
         virtual ~Monster();
 
@@ -117,7 +125,12 @@ class MonsterSm;
             0, //target_x
             0, //target_y
             0, //target direction
-            0  //curent_speed
+            0,  //curent_speed
+			100, //health
+			10, //score_points
+			100, //death_score_bonus
+			10, //damage_inflicted_per_hit
+			10 //damage_suffered_per_hit
         };
 
     private:

--- a/src/player.cpp
+++ b/src/player.cpp
@@ -81,9 +81,9 @@ void Player::computeState(){
     cstate->move();
 }
 
-void Player::collisionWithMonster(){
+void Player::collisionWithMonster(Monster::Monster *m){
     PlayerSm* cstate = pstates[model.state];
-    cstate->collisionWithMonster();
+    cstate->collisionWithMonster(m);
 }
 
 void Player::checkCollisionsWithMonsters(){
@@ -96,7 +96,7 @@ void Player::checkCollisionsWithMonsters(){
             if(i.height()<i.width())
                 step = i.height();
             cstate->moveBy(-step,-step);
-            cstate->collisionWithMonster();
+            cstate->collisionWithMonster(m);
         }
     }
 

--- a/src/player.h
+++ b/src/player.h
@@ -91,7 +91,7 @@ public:
 
     PlayerEnergyGauge* getEnergyGauge();
     PlayerStates getRageStatus();
-    void collisionWithMonster();
+    void collisionWithMonster(Monster::Monster *m);
 
     QRectF collisionBox() const;
 

--- a/src/playersm.cc
+++ b/src/playersm.cc
@@ -21,12 +21,9 @@
 
 
 #include "playersm.h"
+#include "monster.h"
 
 #include <math.h>
-
-#define DAMAGE 10
-#define HIT 10
-
 
 PlayerSm::~PlayerSm(){}
 
@@ -68,8 +65,8 @@ void PlayerNormal::move() {
     moveBy(step,step);
 }
 
-void PlayerNormal::collisionWithMonster() {
-    _model->energy=_model->energy-DAMAGE;
+void PlayerNormal::collisionWithMonster(Monster::Monster *m) {
+    _model->energy=_model->energy - m->hit_inflicted();
     if(_model->energy < 0){
         _model->energy = 0;
         _model->state = dead;
@@ -122,8 +119,9 @@ void PlayerOnRage::move() {
 void PlayerOnRage::toggleRage() {
     _model->state=normal;
 }
-void PlayerOnRage::collisionWithMonster() {
-    _model->score=_model->score+HIT;
+void PlayerOnRage::collisionWithMonster(Monster::Monster *m)  {
+	int score_points = m->hit_suffered();
+    _model->score=_model->score+score_points;
 }
 
 //Player state Dead

--- a/src/playersm.h
+++ b/src/playersm.h
@@ -24,12 +24,16 @@
 #ifndef PLAYERSM_H
 #define PLAYERSM_H
 
+namespace Monster {
+class Monster;
+}
+
 class PlayerSm {
 public:
     virtual void move() = 0;
     virtual void updateEnergy() = 0;
     virtual void toggleRage() = 0;
-    virtual void collisionWithMonster() = 0;
+    virtual void collisionWithMonster(Monster::Monster *m) = 0;
     virtual void enter() {}
     virtual void exit() {}
     virtual ~PlayerSm();
@@ -49,7 +53,7 @@ public:
 
     virtual void move() override ;
 
-    virtual void collisionWithMonster() override ;
+    virtual void collisionWithMonster(Monster::Monster *m) override ;
 
     virtual void toggleRage() override;
     virtual ~PlayerNormal() override;
@@ -74,7 +78,8 @@ public:
 
     virtual void updateEnergy() override ;
 
-    virtual void collisionWithMonster() override {
+    virtual void collisionWithMonster(Monster::Monster *m) override {
+    	Q_UNUSED(m)
         return;
     }
 private:
@@ -89,7 +94,7 @@ public:
 
     virtual void move() override;
     virtual void toggleRage() override ;
-    virtual void collisionWithMonster() override;
+    virtual void collisionWithMonster(Monster::Monster *m) override;
 
     virtual ~PlayerOnRage() override {}
 private:
@@ -103,7 +108,7 @@ public:
     virtual void move() override {}
     virtual void updateEnergy() override {}
     virtual void toggleRage() override {}
-    virtual void collisionWithMonster() override { }
+    virtual void collisionWithMonster(Monster::Monster *m) override {Q_UNUSED(m)}
     virtual ~PlayerDead() override;
 private:
 };

--- a/tests/tst_linear_rotation.h
+++ b/tests/tst_linear_rotation.h
@@ -34,7 +34,12 @@ protected:
         0, //target_x
         0, //target_y
         0, //target direction
-        0  //curent_speed
+        0,  //curent_speed
+		100, //health
+		10, //score_points
+		100, //death_score_bonus
+		10, //damage_inflicted_per_hit
+		10 //damage_suffered_per_hit
     };
 
 };

--- a/tests/tst_perpendicular_direction.h
+++ b/tests/tst_perpendicular_direction.h
@@ -34,7 +34,12 @@ protected:
         0, //target_x
         0, //target_y
         0, //target direction
-        0  //curent_speed
+        0,  //curent_speed
+		100, //health
+		10, //score_points
+		100, //death_score_bonus
+		10, //damage_inflicted_per_hit
+		10 //damage_suffered_per_hit
     };
 
     //void check

--- a/tests/tst_player_collisions.h
+++ b/tests/tst_player_collisions.h
@@ -69,7 +69,8 @@ TEST_F(Collisions, debouncing)
         if(i.height()<i.width())
             step = i.height();
         cstate->moveBy(-step,-step);
-        cstate->collisionWithMonster();
+        //a stubbed monster for testing purpose needs to be added
+        //cstate->collisionWithMonster(m);
     }
 
     cout << "model x (after collision): " << model->pos_x << endl;


### PR DESCRIPTION
Changes:
- src/behaviors.cpp: retrieving current monster instance before to call player->collisionWithMonster()
- src/monster.cpp/h: model extended health, damage and score points; adedd method inflict/suffer damage
- src/player.cpp/h: new collisionWithMonster() interface passing back the monster instance
- src/playersm.cc/h: new collisionWithMonster() interface; callback monster entity to inflict/receive damages and get score points
- tests/tst_linear_rotation.h: monster model update
- tests/tst_perpendicular_direction.h: monster model update
- tests/tst_player_collisions.h: temporary commenting invocation of collisionWithMonster()